### PR TITLE
Add to be able to set filename by command line argument

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 import datetime
 import re
+import argparse
 from urllib.parse import urljoin
 
 import pandas as pd
@@ -7,6 +8,11 @@ import requests
 from bs4 import BeautifulSoup
 
 import simplejson as json
+
+# プログラム引数解析
+ap = argparse.ArgumentParser()
+ap.add_argument('--output', '-o', default='./data/data.json')
+args = ap.parse_args()
 
 JST = datetime.timezone(datetime.timedelta(hours=+9), "JST")
 
@@ -131,5 +137,5 @@ data["patients_summary"] = {
     "date": dt_update,
 }
 
-with open("./data/data.json", "w", encoding="utf-8") as fw:
+with open(args.output, "w", encoding="utf-8") as fw:
     json.dump(data, fw, ignore_nan=True, ensure_ascii=False, indent=4)


### PR DESCRIPTION
コマンドライン引数から出力ファイル名を指定できるようにしました。
このような形で使えます。

```sh
python main.py -o ../covid19/data/data.json
```

引数省略で ./data/data.json へ出力されるので、今までの動作は変わっていないはずです。